### PR TITLE
add line before binding and it's related

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ bytecode kit for java.
 * `@Binding.Monitor` 同步块里监控的对象
 
 
+* `@Binding.LineBefore` 仅搭配`LineBeforeLocation`进行使用，其值为`LineBeforeLocation`中指定的`beforeLine`
+
+
 ### 3. 可编程的异常处理
 
 * `@ExceptionHandler` 在插入的增强代码，可以用`try/catch`块包围起来

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/Binding.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/Binding.java
@@ -403,6 +403,21 @@ public abstract class Binding {
         }
     }
 
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @java.lang.annotation.Target(ElementType.PARAMETER)
+    @BindingParserHandler(parser = LineBeforeBindingParser.class)
+    public static @interface LineBefore {
+
+    }
+
+    public static class LineBeforeBindingParser implements BindingParser {
+        @Override
+        public Binding parse(Annotation annotation) {
+            return new LineBeforeBinding();
+        }
+    }
+
 
     @Documented
     @Retention(RetentionPolicy.RUNTIME)

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/LineBeforeBinding.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/LineBeforeBinding.java
@@ -11,6 +11,10 @@ public class LineBeforeBinding extends Binding {
 
     }
 
+    /**
+     * 匹配指定的{@link LineBeforeLocation}使用
+     * support Location.LineBeforeLocation only
+     */
     @Override
     public void pushOntoStack(InsnList instructions, BindingContext bindingContext) {
         Location location = bindingContext.getLocation();

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/LineBeforeBinding.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/LineBeforeBinding.java
@@ -1,0 +1,30 @@
+package com.alibaba.bytekit.asm.binding;
+
+import com.alibaba.bytekit.asm.location.Location;
+import com.alibaba.bytekit.utils.AsmOpUtils;
+import com.alibaba.deps.org.objectweb.asm.Type;
+import com.alibaba.deps.org.objectweb.asm.tree.InsnList;
+
+public class LineBeforeBinding extends Binding {
+
+    public LineBeforeBinding() {
+
+    }
+
+    @Override
+    public void pushOntoStack(InsnList instructions, BindingContext bindingContext) {
+        Location location = bindingContext.getLocation();
+        if (location instanceof Location.LineBeforeLocation){
+            int targetLine = ((Location.LineBeforeLocation) location).getBeforeLine();
+            AsmOpUtils.push(instructions, targetLine);
+        }else {
+            throw new IllegalArgumentException("support Location.LineBeforeLocation only!");
+        }
+    }
+
+    @Override
+    public Type getType(BindingContext bindingContext) {
+        return Type.getType(int.class);
+    }
+
+}

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/interceptor/InterceptorProcessor.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/interceptor/InterceptorProcessor.java
@@ -49,6 +49,10 @@ public class InterceptorProcessor {
         List<Binding> interceptorBindings = interceptorMethodConfig.getBindings();
 
         for (Location location : locations) {
+            //skip the location if it should be filtered
+            if (location.isEnableFilteredMark() && location.determineFiltered()) {
+                continue;
+            }
 
             // 有三小段代码，1: 保存当前栈上的值的 , 2: 插入的回调的 ， 3：恢复当前栈的
 

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/location/LineBeforeLocationMatcher.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/location/LineBeforeLocationMatcher.java
@@ -1,0 +1,86 @@
+package com.alibaba.bytekit.asm.location;
+
+import com.alibaba.bytekit.asm.MethodProcessor;
+import com.alibaba.bytekit.asm.location.filter.LocationFilter;
+import com.alibaba.deps.org.objectweb.asm.Opcodes;
+import com.alibaba.deps.org.objectweb.asm.tree.AbstractInsnNode;
+import com.alibaba.deps.org.objectweb.asm.tree.InsnNode;
+import com.alibaba.deps.org.objectweb.asm.tree.LineNumberNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * find the location before line.
+ * 1.will only return instance of type {@link  com.alibaba.bytekit.asm.location.Location.LineBeforeLocation}.
+ * 2.will return first method exit location when beforeLine equals -1 .
+ * 3.will only return first matched {@link LineNumberNode}'s previous node even there are multi matched {@link LineNumberNode} in method.
+ * 4.you should add {@link LocationType#EXIT} and {@link LocationType#LINE} in {@link LocationFilter} if you want to avoid the repeat intercept.
+ */
+public class LineBeforeLocationMatcher implements LocationMatcher {
+
+    private Integer beforeLine = 0;
+
+    public LineBeforeLocationMatcher(int beforeLine) {
+        if (beforeLine < -1) {
+            throw new IllegalArgumentException("targetLine must grater than -1");
+        }
+        this.beforeLine = beforeLine;
+    }
+
+    @Override
+    public List<Location> match(MethodProcessor methodProcessor) {
+        List<Location> locations = new ArrayList<Location>();
+        AbstractInsnNode insnNode = methodProcessor.getEnterInsnNode();
+        LocationFilter locationFilter = methodProcessor.getLocationFilter();
+
+        while (insnNode != null) {
+
+            if (beforeLine == -1) {
+                if (insnNode instanceof InsnNode) {
+                    InsnNode node = (InsnNode) insnNode;
+                    if (matchExit(node)) {
+                        boolean filtered = !locationFilter.allow(node, LocationType.EXIT, false);
+                        Location location = new Location.LineBeforeLocation(node, beforeLine, false, filtered);
+                        locations.add(location);
+                        //只取第一个
+                        break;
+                    }
+                }
+            } else {
+                if (insnNode instanceof LineNumberNode) {
+                    LineNumberNode lineNumberNode = (LineNumberNode) insnNode;
+                    if (matchLine(lineNumberNode.line)) {
+                        boolean filtered = !locationFilter.allow(lineNumberNode, LocationType.LINE, false);
+                        //目前因为如果直接返回lineNumberNode，增强完之后会导致行号丢失，暂时没找到原因，因此取上一个节点
+                        Location location = new Location.LineBeforeLocation(lineNumberNode.getPrevious(), beforeLine, false, filtered);
+                        locations.add(location);
+                        //由于会存在多个相同行号的情况，这里只取第一个行号
+                        break;
+                    }
+                }
+            }
+
+            insnNode = insnNode.getNext();
+        }
+        return locations;
+    }
+
+    private boolean matchLine(int line) {
+        return line == beforeLine;
+    }
+
+    public boolean matchExit(InsnNode node) {
+        switch (node.getOpcode()) {
+            case Opcodes.RETURN: // empty stack
+            case Opcodes.IRETURN: // 1 before n/a after
+            case Opcodes.FRETURN: // 1 before n/a after
+            case Opcodes.ARETURN: // 1 before n/a after
+            case Opcodes.LRETURN: // 2 before n/a after
+            case Opcodes.DRETURN: // 2 before n/a after
+                return true;
+        }
+        return false;
+    }
+
+}

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/location/LineBeforeLocationMatcher.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/location/LineBeforeLocationMatcher.java
@@ -23,7 +23,7 @@ public class LineBeforeLocationMatcher implements LocationMatcher {
 
     public LineBeforeLocationMatcher(int beforeLine) {
         if (beforeLine < -1) {
-            throw new IllegalArgumentException("targetLine must grater than -1");
+            throw new IllegalArgumentException("beforeLine must grater than -1");
         }
         this.beforeLine = beforeLine;
     }

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/location/LineBeforeLocationMatcher.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/location/LineBeforeLocationMatcher.java
@@ -13,7 +13,7 @@ import java.util.List;
 /**
  * find the location before line.
  * 1.will only return instance of type {@link  com.alibaba.bytekit.asm.location.Location.LineBeforeLocation}.
- * 2.will return first method exit location when beforeLine equals -1 .
+ * 2.will only return first method exit location when beforeLine equals -1 .
  * 3.will only return first matched {@link LineNumberNode}'s previous node even there are multi matched {@link LineNumberNode} in method.
  * 4.you should add {@link LocationType#EXIT} and {@link LocationType#LINE} in {@link LocationFilter} if you want to avoid the repeat intercept.
  */
@@ -52,7 +52,7 @@ public class LineBeforeLocationMatcher implements LocationMatcher {
                     LineNumberNode lineNumberNode = (LineNumberNode) insnNode;
                     if (matchLine(lineNumberNode.line)) {
                         boolean filtered = !locationFilter.allow(lineNumberNode, LocationType.LINE, false);
-                        //目前因为如果直接返回lineNumberNode，增强完之后会导致行号丢失，暂时没找到原因，因此取上一个节点
+                        //目前因为如果直接返回lineNumberNode，按当前逻辑增强完之后会导致行号丢失，暂时没找到原因，因此向上取一个节点
                         Location location = new Location.LineBeforeLocation(lineNumberNode.getPrevious(), beforeLine, false, filtered);
                         locations.add(location);
                         //由于会存在多个相同行号的情况，这里只取第一个行号
@@ -70,6 +70,9 @@ public class LineBeforeLocationMatcher implements LocationMatcher {
         return line == beforeLine;
     }
 
+    /**
+     * same with {@link com.alibaba.bytekit.asm.location.ExitLocationMatcher}
+     */
     public boolean matchExit(InsnNode node) {
         switch (node.getOpcode()) {
             case Opcodes.RETURN: // empty stack

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/location/Location.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/location/Location.java
@@ -1,11 +1,7 @@
 package com.alibaba.bytekit.asm.location;
 
 import com.alibaba.deps.org.objectweb.asm.Type;
-import com.alibaba.deps.org.objectweb.asm.tree.AbstractInsnNode;
-import com.alibaba.deps.org.objectweb.asm.tree.FieldInsnNode;
-import com.alibaba.deps.org.objectweb.asm.tree.InsnList;
-import com.alibaba.deps.org.objectweb.asm.tree.LocalVariableNode;
-import com.alibaba.deps.org.objectweb.asm.tree.MethodInsnNode;
+import com.alibaba.deps.org.objectweb.asm.tree.*;
 import com.alibaba.bytekit.asm.MethodProcessor;
 import com.alibaba.bytekit.asm.binding.BindingContext;
 import com.alibaba.bytekit.asm.binding.StackSaver;
@@ -23,6 +19,18 @@ public abstract class Location {
     
     boolean stackNeedSave = false;
 
+    /**
+     * the location should be filtered by {@link com.alibaba.bytekit.asm.location.filter.LocationFilter}
+     * 1.enable when {@link Location#enableFilteredMark} is true.
+     * 2.assign value in {@link LocationMatcher} before using.
+     */
+    boolean filtered = false;
+
+    /**
+     * control the {@link Location#filtered} enable or disable to avoid misapply
+     */
+    boolean enableFilteredMark = false;
+
     public Location(AbstractInsnNode insnNode) {
         this(insnNode, false);
     }
@@ -30,6 +38,25 @@ public abstract class Location {
     public Location(AbstractInsnNode insnNode, boolean whenComplete) {
         this.insnNode = insnNode;
         this.whenComplete = whenComplete;
+    }
+
+    public Location(AbstractInsnNode insnNode, boolean whenComplete, boolean filtered) {
+        this.insnNode = insnNode;
+        this.whenComplete = whenComplete;
+        this.enableFilteredMark = true;
+        this.filtered = filtered;
+    }
+
+    public boolean determineFiltered() {
+        if (enableFilteredMark){
+            return filtered;
+        }
+        //throw exp when enableFilteredMark is not assigned to avoid misapply.
+        throw new IllegalStateException("enableFilteredMark is false. filtered is not useful. please check!");
+    }
+
+    public boolean isEnableFilteredMark() {
+        return enableFilteredMark;
     }
 
     public boolean isWhenComplete() {

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/location/Location.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/location/Location.java
@@ -137,6 +137,35 @@ public abstract class Location {
     }
 
     /**
+     * location identifying a method line before trigger point
+     */
+    public static class LineBeforeLocation extends Location {
+        /**
+         * the line at which the trigger point should be inserted before
+         */
+        private int beforeLine;
+
+        public LineBeforeLocation(AbstractInsnNode insnNode, int beforeLine) {
+            super(insnNode);
+            this.beforeLine = beforeLine;
+        }
+
+        public LineBeforeLocation(AbstractInsnNode insnNode, int beforeLine, boolean whenComplete, boolean filtered) {
+            super(insnNode, whenComplete, filtered);
+            this.beforeLine = beforeLine;
+        }
+
+        public int getBeforeLine() {
+            return beforeLine;
+        }
+
+        public LocationType getLocationType() {
+            return LocationType.LINE;
+        }
+
+    }
+
+    /**
      * location identifying a generic access trigger point
      */
     private static abstract class AccessLocation extends Location {

--- a/bytekit-core/src/test/java/com/alibaba/bytekit/asm/location/LineBeforeLocationMatcherFilterTest.java
+++ b/bytekit-core/src/test/java/com/alibaba/bytekit/asm/location/LineBeforeLocationMatcherFilterTest.java
@@ -1,0 +1,131 @@
+package com.alibaba.bytekit.asm.location;
+
+import com.alibaba.bytekit.asm.MethodProcessor;
+import com.alibaba.bytekit.asm.binding.Binding;
+import com.alibaba.bytekit.asm.interceptor.InterceptorProcessor;
+import com.alibaba.bytekit.asm.interceptor.annotation.InterceptorParserUtils;
+import com.alibaba.bytekit.asm.interceptor.annotation.None;
+import com.alibaba.bytekit.asm.location.filter.GroupLocationFilter;
+import com.alibaba.bytekit.asm.location.filter.InvokeCheckLocationFilter;
+import com.alibaba.bytekit.asm.location.filter.LocationFilter;
+import com.alibaba.bytekit.utils.AsmUtils;
+import com.alibaba.bytekit.utils.Decompiler;
+import com.alibaba.bytekit.utils.MatchUtils;
+import com.alibaba.bytekit.utils.ReflectionUtils;
+import com.alibaba.deps.org.objectweb.asm.Type;
+import com.alibaba.deps.org.objectweb.asm.tree.ClassNode;
+import com.alibaba.deps.org.objectweb.asm.tree.MethodNode;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.boot.test.rule.OutputCapture;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+public class LineBeforeLocationMatcherFilterTest {
+
+    @Rule
+    public OutputCapture capture = new OutputCapture();
+
+    public static class SpyAPI {
+
+        public static void atLineBefore(Class<?> clazz, String methodInfo, Object target, Object[] args, int line, Object[] vars, String[] varNames) {
+
+        }
+    }
+
+    public static class SpyLookInterceptor {
+
+        public static void atLineBefore(@Binding.This Object target, @Binding.Class Class<?> clazz,
+                                        @Binding.MethodInfo String methodInfo, @Binding.Args Object[] args,
+                                        @Binding.LineBefore int line,
+                                        @Binding.LocalVars Object[] vars,
+                                        @Binding.LocalVarNames String[] varNames) {
+            SpyAPI.atLineBefore(clazz, methodInfo, target, args, line, vars, varNames);
+        }
+
+    }
+
+    static class LineBeforeSample {
+
+        public int testLineBefore() {
+            int varA = 0;
+            int varB = 1;
+            int varC = 2;
+            int varT = varA + varB * varC;
+            System.out.println("varT:"+varT);
+            return varB * 2;
+        }
+
+    }
+
+
+    /**
+     * 搭配{@link LineBeforeLocationMatcher} 对 {@link Location#filtered} 进行验证
+     * 暴露 match 和 filter 的结果 及 重复enhance的场景
+     */
+    @Test
+    public void testRepeatEnhance() throws Exception {
+        LineBeforeLocationMatcher locationMatcher = new LineBeforeLocationMatcher(59);
+        Method method = ReflectionUtils.findMethod(SpyLookInterceptor.class, "atLineBefore",null);
+        InterceptorProcessor lineBeforeInterceptorProcessor = InterceptorParserUtils.createInterceptorProcessor(method, locationMatcher, true, None.class, Void.class);
+
+        GroupLocationFilter groupLocationFilter = new GroupLocationFilter();
+        //当lookingLineNum>0,指定行的前面进行filter
+        LocationFilter lineBeforeFilter = new InvokeCheckLocationFilter(Type.getInternalName(SpyAPI.class),
+                "atLineBefore", LocationType.LINE);
+        //lookingLineNum=-1,方法退出前进行filter
+        LocationFilter methodExistFilter = new InvokeCheckLocationFilter(Type.getInternalName(SpyAPI.class),
+                "atLineBefore", LocationType.EXIT);
+        groupLocationFilter.addFilter(lineBeforeFilter);
+        groupLocationFilter.addFilter(methodExistFilter);
+
+        ClassNode classNode = AsmUtils.loadClass(LineBeforeSample.class);
+
+        String methodMatcher = "testLineBefore";
+        List<MethodNode> matchedMethods = new ArrayList<MethodNode>();
+        for (MethodNode methodNode : classNode.methods) {
+            if (MatchUtils.wildcardMatch(methodNode.name, methodMatcher)) {
+                matchedMethods.add(methodNode);
+            }
+        }
+
+        new LinkedList<Location>();
+        for (MethodNode methodNode : matchedMethods) {
+            MethodProcessor methodProcessor = new MethodProcessor(classNode, methodNode, groupLocationFilter);
+            //首次增强
+            List<Location> locations = lineBeforeInterceptorProcessor.process(methodProcessor);
+            //不为空则表示match到了
+            Assertions.assertThat(locations).isNotEmpty();
+
+            byte[] bytes = AsmUtils.toBytes(classNode);
+            System.out.println(Decompiler.decompile(bytes));
+
+            //只增强一个
+            Assertions.assertThat(
+                            AsmUtils.findMethodInsnNode(methodNode, Type.getInternalName(LineBeforeLocationMatcherFilterTest.SpyAPI.class), "atLineBefore"))
+                    .size().isEqualTo(1);
+
+
+
+            //再次增强
+            locations = lineBeforeInterceptorProcessor.process(methodProcessor);
+            //第二次依旧能match到
+            Assertions.assertThat(locations).isNotEmpty();
+
+            byte[] bytes2 = AsmUtils.toBytes(classNode);
+            System.out.println(Decompiler.decompile(bytes2));
+
+            //再次增强，因为是重复的，所以最终只有一条
+            Assertions.assertThat(
+                            AsmUtils.findMethodInsnNode(methodNode, Type.getInternalName(LineBeforeLocationMatcherFilterTest.SpyAPI.class), "atLineBefore"))
+                    .size().isEqualTo(1);
+
+
+
+        }
+    }
+}

--- a/bytekit-core/src/test/java/com/alibaba/bytekit/asm/location/LineBeforeLocationMatcherTest.java
+++ b/bytekit-core/src/test/java/com/alibaba/bytekit/asm/location/LineBeforeLocationMatcherTest.java
@@ -1,0 +1,97 @@
+package com.alibaba.bytekit.asm.location;
+
+import com.alibaba.bytekit.asm.MethodProcessor;
+import com.alibaba.bytekit.asm.binding.Binding;
+import com.alibaba.bytekit.asm.interceptor.InterceptorProcessor;
+import com.alibaba.bytekit.asm.interceptor.annotation.InterceptorParserUtils;
+import com.alibaba.bytekit.asm.interceptor.annotation.None;
+import com.alibaba.bytekit.utils.*;
+import com.alibaba.deps.org.objectweb.asm.tree.ClassNode;
+import com.alibaba.deps.org.objectweb.asm.tree.MethodNode;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.boot.test.rule.OutputCapture;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LineBeforeLocationMatcherTest {
+
+    @Rule
+    public OutputCapture capture = new OutputCapture();
+
+    public static class SpyLookInterceptor {
+
+        public static void atLineBefore(@Binding.This Object target, @Binding.Class Class<?> clazz,
+                                        @Binding.MethodInfo String methodInfo, @Binding.Args Object[] args,
+                                        @Binding.LineBefore int line,
+                                        @Binding.LocalVars Object[] vars,
+                                        @Binding.LocalVarNames String[] varNames) {
+            System.out.println("atLineBefore-args:" + clazz + methodInfo + target + args + line + vars + varNames);
+        }
+
+    }
+
+    static class LineBeforeSample {
+
+        public int testLineBefore() {
+            int varA = 0;
+            int varB = 1;
+            int varC = 2;
+            int varT = varA + varB * varC;
+            System.out.println("varT:"+varT);
+            return varB * 2;
+        }
+
+    }
+
+
+    @Test
+    public void testMatched() throws Exception {
+        beforeLine(46);
+        assertThat(capture.toString()).contains("atLineBefore-args:");
+    }
+
+    @Test
+    public void testUnMatched() throws Exception {
+        beforeLine(1000);
+        assertThat(capture.toString()).doesNotContain("atLineBefore-args:");
+    }
+
+    @Test
+    public void testMethodExit() throws Exception {
+        beforeLine(-1);
+        assertThat(capture.toString()).contains("atLineBefore-args:");
+    }
+
+    private List<Location> beforeLine(int beforeLine) throws Exception {
+        LineBeforeLocationMatcher locationMatcher = new LineBeforeLocationMatcher(beforeLine);
+        Method method = ReflectionUtils.findMethod(SpyLookInterceptor.class, "atLineBefore",null);
+        InterceptorProcessor lineBeforeInterceptorProcessor = InterceptorParserUtils.createInterceptorProcessor(method, locationMatcher, true, None.class, Void.class);
+
+        ClassNode classNode = AsmUtils.loadClass(LineBeforeSample.class);
+
+        String methodMatcher = "testLineBefore";
+        List<MethodNode> matchedMethods = new ArrayList<MethodNode>();
+        for (MethodNode methodNode : classNode.methods) {
+            if (MatchUtils.wildcardMatch(methodNode.name, methodMatcher)) {
+                matchedMethods.add(methodNode);
+            }
+        }
+
+        List<Location> locations = new LinkedList<Location>();
+        for (MethodNode methodNode : matchedMethods) {
+            MethodProcessor methodProcessor = new MethodProcessor(classNode, methodNode);
+            locations.addAll(lineBeforeInterceptorProcessor.process(methodProcessor));
+        }
+
+        byte[] bytes = AsmUtils.toBytes(classNode);
+        System.out.println(Decompiler.decompile(bytes));
+        return locations;
+    }
+
+}


### PR DESCRIPTION
第一次提交PR,有描述不清楚的地方还请见谅并沟通,thanks

### 两个主要改动:

1. 在`Location`基类中增加了`filtered`的标记,代表该`Location`被`Matcher`处理后,是否被`LocationFilter`过滤掉

2. 添加`BeforeLine`类型的`Binding`及相关的`Matcher`

### 为什么需要暴露是否被过滤掉的状态呢?

- 因为在使用行来进行增强(`InterceptorProcessor#process`)时发现如果没有明确出 匹配失败 和 被过滤 两种状态的话,在外层逻辑上没法做对应的处理(Arthas中无法判定是否需要注册listener)

### 为什么需要定义一个BeforeLine呢?用Line不行嘛?

- 场景: 期待在Arthas获取到本地变量,选择的实现方式是在某行之前进行插桩
- `Binding`时行号传递: Line使用了`LineNumberNode`中的行号,当我需要在 **方法退出前** 进行插入时,这边使用了-1来代表这个位置,所以Line无法给到-1这个值,在注册监听器时,这是个问题
- `LocationFilter`过滤问题: `LineLocationMatcher`目前是没有应用过滤的,也就是会导致重复增强
- 行号重复: 目前在增强kotlin类的时候发现,kotlin编译出来的class文件是存在重复行号问题的,使用`LineLocationMatcher`时候会尝试增强多个相同行号,`LineBeforeLocationMatcher`通过只取最前的一个来规避这个问题

**thanks again**