### PR TITLE
为 LocalVarsBinding 和 LocalVarNamesBinding 添加 exclude-pattern 支持

### DIFF
--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/Binding.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/Binding.java
@@ -82,6 +82,8 @@ public abstract class Binding {
     @java.lang.annotation.Target(ElementType.PARAMETER)
     @BindingParserHandler(parser = LocalVarsBindingParser.class)
     public static @interface LocalVars {
+
+        String excludePattern() default "";
         
         boolean optional() default false;
 
@@ -89,6 +91,10 @@ public abstract class Binding {
     public static class LocalVarsBindingParser implements BindingParser {
         @Override
         public Binding parse(Annotation annotation) {
+            if (annotation instanceof LocalVars){
+                LocalVars LocalVars = (LocalVars) annotation;
+                return new LocalVarsBinding(LocalVars.excludePattern());
+            }
             return new LocalVarsBinding();
         }
         
@@ -99,13 +105,19 @@ public abstract class Binding {
     @java.lang.annotation.Target(ElementType.PARAMETER)
     @BindingParserHandler(parser = LocalVarNamesBindingParser.class)
     public static @interface LocalVarNames {
-        
+
+        String excludePattern() default "";
+
         boolean optional() default false;
 
     }
     public static class LocalVarNamesBindingParser implements BindingParser {
         @Override
         public Binding parse(Annotation annotation) {
+            if (annotation instanceof LocalVarNames){
+                LocalVarNames localVarNames = (LocalVarNames) annotation;
+                return new LocalVarNamesBinding(localVarNames.excludePattern());
+            }
             return new LocalVarNamesBinding();
         }
         

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/LocalVarNamesBinding.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/LocalVarNamesBinding.java
@@ -1,7 +1,10 @@
 package com.alibaba.bytekit.asm.binding;
 
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 
+import com.alibaba.bytekit.utils.MatchUtils;
 import com.alibaba.deps.org.objectweb.asm.Type;
 import com.alibaba.deps.org.objectweb.asm.tree.AbstractInsnNode;
 import com.alibaba.deps.org.objectweb.asm.tree.InsnList;
@@ -10,11 +13,29 @@ import com.alibaba.bytekit.utils.AsmOpUtils;
 
 public class LocalVarNamesBinding extends Binding {
 
+    private String excludePattern;
+
+    public LocalVarNamesBinding(String excludePattern) {
+        this.excludePattern = excludePattern;
+    }
+
+    public LocalVarNamesBinding() {
+    }
+
     @Override
     public void pushOntoStack(InsnList instructions, BindingContext bindingContext) {
         AbstractInsnNode currentInsnNode = bindingContext.getLocation().getInsnNode();
-        List<LocalVariableNode> results = AsmOpUtils
-                .validVariables(bindingContext.getMethodProcessor().getMethodNode().localVariables, currentInsnNode);
+
+        List<LocalVariableNode> localVariables = new LinkedList<LocalVariableNode>(bindingContext.getMethodProcessor().getMethodNode().localVariables);
+        if (excludePattern != null && !excludePattern.isEmpty()){
+            Iterator<LocalVariableNode> it = localVariables.iterator();
+            while(it.hasNext()){
+                LocalVariableNode localVariableNode = it.next();
+                if (MatchUtils.wildcardMatch(localVariableNode.name,excludePattern)) it.remove();
+            }
+        }
+
+        List<LocalVariableNode> results = AsmOpUtils.validVariables(localVariables, currentInsnNode);
 
         AsmOpUtils.push(instructions, results.size());
         AsmOpUtils.newArray(instructions, AsmOpUtils.STRING_TYPE);
@@ -34,4 +55,11 @@ public class LocalVarNamesBinding extends Binding {
         return AsmOpUtils.STRING_ARRAY_TYPE;
     }
 
+    public String getExcludePattern() {
+        return excludePattern;
+    }
+
+    public void setExcludePattern(String excludePattern) {
+        this.excludePattern = excludePattern;
+    }
 }

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/LocalVarsBinding.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/LocalVarsBinding.java
@@ -1,7 +1,10 @@
 package com.alibaba.bytekit.asm.binding;
 
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 
+import com.alibaba.bytekit.utils.MatchUtils;
 import com.alibaba.deps.org.objectweb.asm.Type;
 import com.alibaba.deps.org.objectweb.asm.tree.AbstractInsnNode;
 import com.alibaba.deps.org.objectweb.asm.tree.InsnList;
@@ -15,13 +18,30 @@ import com.alibaba.bytekit.utils.AsmOpUtils;
  */
 public class LocalVarsBinding extends Binding{
 
+    private String excludePattern;
+
+    public LocalVarsBinding(String excludePattern) {
+        this.excludePattern = excludePattern;
+    }
+
+    public LocalVarsBinding() {
+    }
+
     @Override
     public void pushOntoStack(InsnList instructions, BindingContext bindingContext) {
 
         AbstractInsnNode currentInsnNode = bindingContext.getLocation().getInsnNode();
 
-        List<LocalVariableNode> results = AsmOpUtils
-                .validVariables(bindingContext.getMethodProcessor().getMethodNode().localVariables, currentInsnNode);
+        List<LocalVariableNode> localVariables = new LinkedList<LocalVariableNode>(bindingContext.getMethodProcessor().getMethodNode().localVariables);
+        if (excludePattern != null && !excludePattern.isEmpty()){
+            Iterator<LocalVariableNode> it = localVariables.iterator();
+            while(it.hasNext()){
+                LocalVariableNode localVariableNode = it.next();
+                if (MatchUtils.wildcardMatch(localVariableNode.name,excludePattern)) it.remove();
+            }
+        }
+
+        List<LocalVariableNode> results = AsmOpUtils.validVariables(localVariables, currentInsnNode);
 
         AsmOpUtils.push(instructions, results.size());
         AsmOpUtils.newArray(instructions, AsmOpUtils.OBJECT_TYPE);
@@ -45,4 +65,11 @@ public class LocalVarsBinding extends Binding{
         return AsmOpUtils.OBJECT_ARRAY_TYPE;
     }
 
+    public String getExcludePattern() {
+        return excludePattern;
+    }
+
+    public void setExcludePattern(String excludePattern) {
+        this.excludePattern = excludePattern;
+    }
 }


### PR DESCRIPTION
### 事出有因
这边在尝试增强kotlin1.4编译出来的class时,在一些lambda表达式中会出现增强失败的情况,其中使用了LocalVarsBinding,经过公司大佬的排查,发现kotlin会写入一些不会使用到的变量到 LocalVariableTable ,并且 LocalVarsBinding 在读取 LocalVariableTable 时,不会判定该变量是否有使用,因此增强后的字节码会校验失败.

> Retransform时候的报错信息:
![1234567](https://user-images.githubusercontent.com/38056190/215273462-dd2cccd1-5b2b-419e-98b9-c9eed2931724.png)

> Decompile时候的报错信息:
![企业微信截图_af9558e3-4b06-4052-a155-2e71eecccdbb](https://user-images.githubusercontent.com/38056190/215273489-a324a28b-9412-49f2-bdab-f92d729cd37d.png)

### 期望的解决方法
如题,期待是能提供一个 exclude-pattern 支持,目前编译器产生的变量一般都是带有$的,通过表达式排除包含$的变量,能一定程度上解决这个问题.

### 如何复现
代码: https://github.com/isadliliying/bytekit/tree/wingli-before-line-enhance-error
增强报错的单元测试: com.alibaba.bytekit.asm.location.LineBeforeLocationMatcherEnhanceTest#testLocalVarsEnhanceError
增强成功的单元测试: com.alibaba.bytekit.asm.location.LineBeforeLocationMatcherEnhanceTest#testLocalVarsEnhanceSuccess

@hengyunabc 烦请大佬有空也帮忙看下是否合理
