### PR TITLE
为 arthas 中实现look命令提供一些通用的支持

### DIFF
--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/Binding.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/Binding.java
@@ -82,6 +82,8 @@ public abstract class Binding {
     @java.lang.annotation.Target(ElementType.PARAMETER)
     @BindingParserHandler(parser = LocalVarsBindingParser.class)
     public static @interface LocalVars {
+
+        String excludePattern() default "";
         
         boolean optional() default false;
 
@@ -89,6 +91,10 @@ public abstract class Binding {
     public static class LocalVarsBindingParser implements BindingParser {
         @Override
         public Binding parse(Annotation annotation) {
+            if (annotation instanceof LocalVars){
+                LocalVars LocalVars = (LocalVars) annotation;
+                return new LocalVarsBinding(LocalVars.excludePattern());
+            }
             return new LocalVarsBinding();
         }
         
@@ -99,13 +105,19 @@ public abstract class Binding {
     @java.lang.annotation.Target(ElementType.PARAMETER)
     @BindingParserHandler(parser = LocalVarNamesBindingParser.class)
     public static @interface LocalVarNames {
-        
+
+        String excludePattern() default "";
+
         boolean optional() default false;
 
     }
     public static class LocalVarNamesBindingParser implements BindingParser {
         @Override
         public Binding parse(Annotation annotation) {
+            if (annotation instanceof LocalVarNames){
+                LocalVarNames localVarNames = (LocalVarNames) annotation;
+                return new LocalVarNamesBinding(localVarNames.excludePattern());
+            }
             return new LocalVarNamesBinding();
         }
         

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/Binding.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/Binding.java
@@ -425,7 +425,25 @@ public abstract class Binding {
         boolean optional() default false;
 
     }
-    
+
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @java.lang.annotation.Target(ElementType.PARAMETER)
+    @BindingParserHandler(parser = StringBindingParser.class)
+    public static @interface StringValue {
+
+        String value() default "";
+
+    }
+
+    public static class StringBindingParser implements BindingParser {
+        @Override
+        public Binding parse(Annotation annotation) {
+            StringValue stringValue = (StringValue) annotation;
+            return new StringBinding(stringValue.value());
+        }
+    }
+
     public static class MonitorBindingParser implements BindingParser {
         @Override
         public Binding parse(Annotation annotation) {

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/LocalVarNamesBinding.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/LocalVarNamesBinding.java
@@ -1,7 +1,10 @@
 package com.alibaba.bytekit.asm.binding;
 
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 
+import com.alibaba.bytekit.utils.MatchUtils;
 import com.alibaba.deps.org.objectweb.asm.Type;
 import com.alibaba.deps.org.objectweb.asm.tree.AbstractInsnNode;
 import com.alibaba.deps.org.objectweb.asm.tree.InsnList;
@@ -10,11 +13,29 @@ import com.alibaba.bytekit.utils.AsmOpUtils;
 
 public class LocalVarNamesBinding extends Binding {
 
+    private String excludePattern;
+
+    public LocalVarNamesBinding(String excludePattern) {
+        this.excludePattern = excludePattern;
+    }
+
+    public LocalVarNamesBinding() {
+    }
+
     @Override
     public void pushOntoStack(InsnList instructions, BindingContext bindingContext) {
         AbstractInsnNode currentInsnNode = bindingContext.getLocation().getInsnNode();
-        List<LocalVariableNode> results = AsmOpUtils
-                .validVariables(bindingContext.getMethodProcessor().getMethodNode().localVariables, currentInsnNode);
+
+        List<LocalVariableNode> localVariables = new LinkedList<LocalVariableNode>(bindingContext.getMethodProcessor().getMethodNode().localVariables);
+        if (excludePattern != null && !excludePattern.isEmpty()){
+            Iterator<LocalVariableNode> it = localVariables.iterator();
+            while(it.hasNext()){
+                LocalVariableNode localVariableNode = it.next();
+                if (MatchUtils.wildcardMatch(localVariableNode.name,excludePattern)) it.remove();
+            }
+        }
+
+        List<LocalVariableNode> results = AsmOpUtils.validVariables(localVariables, currentInsnNode);
 
         AsmOpUtils.push(instructions, results.size());
         AsmOpUtils.newArray(instructions, AsmOpUtils.STRING_TYPE);
@@ -34,4 +55,11 @@ public class LocalVarNamesBinding extends Binding {
         return AsmOpUtils.STRING_ARRAY_TYPE;
     }
 
+    public String getExcludePattern() {
+        return excludePattern;
+    }
+
+    public void setExcludePattern(String excludePattern) {
+        this.excludePattern = excludePattern;
+    }
 }

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/LocalVarsBinding.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/LocalVarsBinding.java
@@ -1,7 +1,10 @@
 package com.alibaba.bytekit.asm.binding;
 
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 
+import com.alibaba.bytekit.utils.MatchUtils;
 import com.alibaba.deps.org.objectweb.asm.Type;
 import com.alibaba.deps.org.objectweb.asm.tree.AbstractInsnNode;
 import com.alibaba.deps.org.objectweb.asm.tree.InsnList;
@@ -15,13 +18,30 @@ import com.alibaba.bytekit.utils.AsmOpUtils;
  */
 public class LocalVarsBinding extends Binding{
 
+    private String excludePattern;
+
+    public LocalVarsBinding(String excludePattern) {
+        this.excludePattern = excludePattern;
+    }
+
+    public LocalVarsBinding() {
+    }
+
     @Override
     public void pushOntoStack(InsnList instructions, BindingContext bindingContext) {
 
         AbstractInsnNode currentInsnNode = bindingContext.getLocation().getInsnNode();
 
-        List<LocalVariableNode> results = AsmOpUtils
-                .validVariables(bindingContext.getMethodProcessor().getMethodNode().localVariables, currentInsnNode);
+        List<LocalVariableNode> localVariables = new LinkedList<LocalVariableNode>(bindingContext.getMethodProcessor().getMethodNode().localVariables);
+        if (excludePattern != null && !excludePattern.isEmpty()){
+            Iterator<LocalVariableNode> it = localVariables.iterator();
+            while(it.hasNext()){
+                LocalVariableNode localVariableNode = it.next();
+                if (MatchUtils.wildcardMatch(localVariableNode.name,excludePattern)) it.remove();
+            }
+        }
+
+        List<LocalVariableNode> results = AsmOpUtils.validVariables(localVariables, currentInsnNode);
 
         AsmOpUtils.push(instructions, results.size());
         AsmOpUtils.newArray(instructions, AsmOpUtils.OBJECT_TYPE);
@@ -45,4 +65,11 @@ public class LocalVarsBinding extends Binding{
         return AsmOpUtils.OBJECT_ARRAY_TYPE;
     }
 
+    public String getExcludePattern() {
+        return excludePattern;
+    }
+
+    public void setExcludePattern(String excludePattern) {
+        this.excludePattern = excludePattern;
+    }
 }

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/StringBinding.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/binding/StringBinding.java
@@ -1,0 +1,41 @@
+package com.alibaba.bytekit.asm.binding;
+
+import com.alibaba.bytekit.utils.AsmOpUtils;
+import com.alibaba.deps.org.objectweb.asm.Type;
+import com.alibaba.deps.org.objectweb.asm.tree.InsnList;
+
+/**
+ * 字符串的Binding
+ * 参照了 {@link IntBinding}
+ */
+public class StringBinding extends Binding {
+
+    private String value;
+
+
+    public StringBinding(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * 提供value覆盖入口
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public void pushOntoStack(InsnList instructions, BindingContext bindingContext) {
+        AsmOpUtils.push(instructions, value);
+    }
+
+    @Override
+    public Type getType(BindingContext bindingContext) {
+        return Type.getType(String.class);
+    }
+
+}

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/interceptor/InterceptorProcessor.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/interceptor/InterceptorProcessor.java
@@ -49,6 +49,10 @@ public class InterceptorProcessor {
         List<Binding> interceptorBindings = interceptorMethodConfig.getBindings();
 
         for (Location location : locations) {
+            //skip the location if it should be filtered
+            if (location.isEnableFilteredMark() && location.determineFiltered()) {
+                continue;
+            }
 
             // 有三小段代码，1: 保存当前栈上的值的 , 2: 插入的回调的 ， 3：恢复当前栈的
 

--- a/bytekit-core/src/main/java/com/alibaba/bytekit/asm/location/Location.java
+++ b/bytekit-core/src/main/java/com/alibaba/bytekit/asm/location/Location.java
@@ -1,11 +1,7 @@
 package com.alibaba.bytekit.asm.location;
 
 import com.alibaba.deps.org.objectweb.asm.Type;
-import com.alibaba.deps.org.objectweb.asm.tree.AbstractInsnNode;
-import com.alibaba.deps.org.objectweb.asm.tree.FieldInsnNode;
-import com.alibaba.deps.org.objectweb.asm.tree.InsnList;
-import com.alibaba.deps.org.objectweb.asm.tree.LocalVariableNode;
-import com.alibaba.deps.org.objectweb.asm.tree.MethodInsnNode;
+import com.alibaba.deps.org.objectweb.asm.tree.*;
 import com.alibaba.bytekit.asm.MethodProcessor;
 import com.alibaba.bytekit.asm.binding.BindingContext;
 import com.alibaba.bytekit.asm.binding.StackSaver;
@@ -23,6 +19,18 @@ public abstract class Location {
     
     boolean stackNeedSave = false;
 
+    /**
+     * the location should be filtered by {@link com.alibaba.bytekit.asm.location.filter.LocationFilter}
+     * 1.enable when {@link Location#enableFilteredMark} is true.
+     * 2.assign value in {@link LocationMatcher} before using.
+     */
+    boolean filtered = false;
+
+    /**
+     * control the {@link Location#filtered} enable or disable to avoid misapply
+     */
+    boolean enableFilteredMark = false;
+
     public Location(AbstractInsnNode insnNode) {
         this(insnNode, false);
     }
@@ -30,6 +38,25 @@ public abstract class Location {
     public Location(AbstractInsnNode insnNode, boolean whenComplete) {
         this.insnNode = insnNode;
         this.whenComplete = whenComplete;
+    }
+
+    public Location(AbstractInsnNode insnNode, boolean whenComplete, boolean filtered) {
+        this.insnNode = insnNode;
+        this.whenComplete = whenComplete;
+        this.enableFilteredMark = true;
+        this.filtered = filtered;
+    }
+
+    public boolean determineFiltered() {
+        if (enableFilteredMark){
+            return filtered;
+        }
+        //throw exp when enableFilteredMark is not assigned to avoid misapply.
+        throw new IllegalStateException("enableFilteredMark is false. filtered is not useful. please check!");
+    }
+
+    public boolean isEnableFilteredMark() {
+        return enableFilteredMark;
     }
 
     public boolean isWhenComplete() {

--- a/bytekit-core/src/test/java/com/alibaba/bytekit/asm/binding/StringBindingTest.java
+++ b/bytekit-core/src/test/java/com/alibaba/bytekit/asm/binding/StringBindingTest.java
@@ -1,0 +1,62 @@
+package com.alibaba.bytekit.asm.binding;
+
+import com.alibaba.bytekit.asm.interceptor.TestHelper;
+import com.alibaba.bytekit.asm.interceptor.annotation.AtEnter;
+import com.alibaba.bytekit.utils.Decompiler;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.boot.test.rule.OutputCapture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StringBindingTest {
+    @Rule
+    public OutputCapture capture = new OutputCapture();
+
+    static class Sample {
+
+        public int testStringValue() {
+            int varInt = 123;
+            long varLong = 1234L;
+            byte varByte = 127;
+            short varShort = 1223;
+            boolean varBoolean = false;
+            float varFloat = 0.8f;
+            double varDouble = 0.3d;
+            String varString = "str-wingli";
+            int[] varIArray = new int[]{2, 3, 5};
+            Object varObject = new Object();
+            Object[] varObjectArray = new Object[]{new Object(), new Object()};
+
+            double total = varInt + varLong + varShort;
+            System.out.println(varString + total);
+
+            return varInt * 3;
+        }
+
+    }
+
+    public static class TestStringBindingInterceptor {
+
+        @AtEnter
+        public static void atStringBinding(@Binding.StringValue("pass-string") String stringValue) {
+            System.err.println("string value:" + stringValue);
+        }
+
+    }
+
+    @Test
+    public void testStringValue() throws Exception {
+        TestHelper helper = TestHelper.builder().interceptorClass(TestStringBindingInterceptor.class).methodMatcher("testStringValue")
+                .redefine(true);
+        byte[] bytes = helper.process(Sample.class);
+
+        new Sample().testStringValue();
+
+        System.err.println(Decompiler.decompile(bytes));
+
+        assertThat(capture.toString()).contains("string value:pass-string");
+    }
+
+
+}


### PR DESCRIPTION
# no1. commit: 9e62fbc7cd85da9684dc7753b0cc059b7dc591cb
### 事出有因
这边在尝试增强kotlin1.4编译出来的class时,在一些lambda表达式中会出现增强失败的情况,其中使用了LocalVarsBinding,经过公司大佬的排查,发现kotlin会写入一些不会使用到的变量到 LocalVariableTable ,并且 LocalVarsBinding 在读取 LocalVariableTable 时,不会判定该变量是否有使用,因此增强后的字节码会校验失败.

> Retransform时候的报错信息:
![1234567](https://user-images.githubusercontent.com/38056190/215273462-dd2cccd1-5b2b-419e-98b9-c9eed2931724.png)

> Decompile时候的报错信息:
![企业微信截图_af9558e3-4b06-4052-a155-2e71eecccdbb](https://user-images.githubusercontent.com/38056190/215273489-a324a28b-9412-49f2-bdab-f92d729cd37d.png)

### 期望的解决方法
如题,期待是能提供一个 exclude-pattern 支持,目前编译器产生的变量一般都是带有$的,通过表达式排除包含$的变量,能一定程度上解决这个问题.

### 如何复现
代码: https://github.com/isadliliying/bytekit/tree/wingli-before-line-enhance-error
增强报错的单元测试: com.alibaba.bytekit.asm.location.LineBeforeLocationMatcherEnhanceTest#testLocalVarsEnhanceError
增强成功的单元测试: com.alibaba.bytekit.asm.location.LineBeforeLocationMatcherEnhanceTest#testLocalVarsEnhanceSuccess


# no2. commit: 86f15a33437f17312933ca3dd48f93374ce0c58f
### 原因
希望使用注解传递一个String类型的参数,目前使用场景是在Arthas中进行监听时,使用传递该值作为监听的key

# no3. commit: cfb2b9be6e4fb434513adca66eee22a872161a2e
### 为什么需要暴露是否被过滤掉的状态呢?
因为在使用行来进行增强(`InterceptorProcessor#process`)时发现如果没有明确出 匹配失败 和 被过滤 两种状态的话,在外层逻辑上没法做对应的处理(Arthas中无法判定是否需要注册listener)